### PR TITLE
Fix using stubs

### DIFF
--- a/lib/tcl-duktape.c
+++ b/lib/tcl-duktape.c
@@ -320,11 +320,12 @@ Tclduktape_Init(Tcl_Interp *interp)
 {
     Tcl_Namespace *nsPtr;
     struct DuktapeData *duktape_data;
-    duktape_data = (struct DuktapeData *) ckalloc(sizeof(struct DuktapeData));
 
     if (Tcl_InitStubs(interp, TCL_VERSION, 0) == NULL) {
         return TCL_ERROR;
     }
+
+    duktape_data = (struct DuktapeData *) ckalloc(sizeof(struct DuktapeData));
 
     /* Create the namespace. */
     if (Tcl_FindNamespace(interp, NS, NULL, 0) == NULL) {

--- a/lib/tcl-duktape.c
+++ b/lib/tcl-duktape.c
@@ -321,9 +321,11 @@ Tclduktape_Init(Tcl_Interp *interp)
     Tcl_Namespace *nsPtr;
     struct DuktapeData *duktape_data;
 
+#ifdef USE_TCL_STUBS
     if (Tcl_InitStubs(interp, TCL_VERSION, 0) == NULL) {
         return TCL_ERROR;
     }
+#endif
 
     duktape_data = (struct DuktapeData *) ckalloc(sizeof(struct DuktapeData));
 


### PR DESCRIPTION
ckalloc() is a stubs-ified function, so if compiling with stubs it needs to be deferred until stubs are initialized.

Additionally, there's no benefit in trying to initialize stubs if stubs are not in use -- though if it does not fail, maybe it does not matter.